### PR TITLE
Test cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,18 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+version_scheme = "post-release"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli =  false
+doctest_optionflags = ["ELLIPSIS", "NORMALIZE_WHITESPACE",]
+addopts = "--strict-markers"
+markers = "subscript"
+filterwarnings = [
+    "ignore:currentThread:DeprecationWarning",
+    "ignore:co_lnotab:DeprecationWarning",
+]
 
 [tool.coverage.run]
 branch = true

--- a/redis_ipc_msg_test.py
+++ b/redis_ipc_msg_test.py
@@ -8,6 +8,7 @@ import pytest
 import redis
 
 import redis_ipc
+from redis_ipc import BadMessage, MsgTimeout, NoRedis, NotDict
 from redis_ipc import RedisClient as rc
 from redis_ipc import RedisServer as rs
 from redis_ipc import get_serveraddr


### PR DESCRIPTION
* add pytest cfg block, ignore specific deprecation warnings
* add custom exception imports to test file
* set version_scheme to post-release